### PR TITLE
Suggestion: Extend config to port and serial device

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -1,4 +1,5 @@
 debug: true
+serialdevice: /dev/ttyUSB0
 devices:
     'packet': device name
     'packet':
@@ -7,5 +8,6 @@ publish_unknown: False
 mqtt:
     prefix: homeassistant
     host: hostname
+    port: 1883
     username: username
     password: password

--- a/src/rfxtrx2mqtt.py
+++ b/src/rfxtrx2mqtt.py
@@ -277,11 +277,12 @@ def setup_logging(config):
 
 def mqtt_connect(config):
     HOSTNAME = config["mqtt"]["host"]
+    MQTTPORT = config["mqtt"]["port"]
     USERNAME = config["mqtt"]["username"]
     PASSWORD = config["mqtt"]["password"]
 
     mqttc.username_pw_set(USERNAME, PASSWORD)
-    mqttc.connect(host=HOSTNAME)
+    mqttc.connect(host=HOSTNAME, port=MQTTPORT)
 
 
 def main():
@@ -296,7 +297,7 @@ def main():
     setup_devices(config)
 
     LOG.info("Waiting for events")
-    device = "/dev/ttyUSB0"
+    device = config["serialdevice"]
     # Threads be running with this callback.
     rfx_object = rfxtrxmod.Connect(
         device, functools.partial(event_callback, config), debug=True


### PR DESCRIPTION
Thank you for this excellent software, it turned out to be exactly what I need.


I've extended the configuration slightly to accommodate my needs.

I'm pointing the serialdevice to /dev/serial/by-id/usb-RFXCOM_RFXtrx433_06VTMS0K-if00-port0 and for some reason I'm running mqtt on a non-standard port.

This PR is just a suggestion at this point, I think it would be better to make those config items optional and have sane defaults (like what was there before)