### PR TITLE
Suggestion: Use newer python and smaller alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11-alpine
 
 COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Another suggestion, the original python:3.8 image is almost 1GB, where this alpine image is 73.7MB when it's built.

For me this was necessary, since the tiny machine I run this on doesn't have much disk space to begin with (only 8GB).